### PR TITLE
Rate limiting

### DIFF
--- a/src/WhatTheDob.Application/Interfaces/Services/IMenuService.cs
+++ b/src/WhatTheDob.Application/Interfaces/Services/IMenuService.cs
@@ -9,7 +9,7 @@ namespace WhatTheDob.Application.Interfaces.Services
     /// </summary>
     public interface IMenuService
     {
-        Task<Menu> GetMenuAsync(string date, int campusId, int mealId);
+        Task<Menu?> GetMenuAsync(string date, int campusId, int mealId);
         // Fetch all menus from external API, will process a specific date if specified
         Task<List<Menu>> FetchMenusFromApiAsync(string date = "");
         Task<IEnumerable<Campus>> GetCampusesAsync();

--- a/src/WhatTheDob.Application/Interfaces/Services/IMenuService.cs
+++ b/src/WhatTheDob.Application/Interfaces/Services/IMenuService.cs
@@ -14,6 +14,6 @@ namespace WhatTheDob.Application.Interfaces.Services
         Task<List<Menu>> FetchMenusFromApiAsync(string date = "");
         Task<IEnumerable<Campus>> GetCampusesAsync();
         Task<IEnumerable<Meal>> GetMealsAsync();
-        Task SubmitUserRatingAsync(string sessionId, string itemValue, int rating);
+        Task<(bool IsSuccess, string? FailureReason)> SubmitUserRatingAsync(string sessionId, string itemValue, int rating);
     }
 }

--- a/src/WhatTheDob.Application/Interfaces/Services/IRatingThrottleService.cs
+++ b/src/WhatTheDob.Application/Interfaces/Services/IRatingThrottleService.cs
@@ -1,0 +1,12 @@
+using System;
+namespace WhatTheDob.Application.Interfaces.Services
+{
+    public interface IRatingThrottleService
+    {
+        /// <summary>
+        /// Checks whether a submission for the given sessionId is allowed and records it if allowed.
+        /// Returns true when the submission is permitted, false when the rate limit has been exceeded.
+        /// </summary>
+        bool IsAllowedAndRecord(string sessionId);
+    }
+}

--- a/src/WhatTheDob.Infrastructure/Services/MenuService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/MenuService.cs
@@ -21,7 +21,7 @@ namespace WhatTheDob.Infrastructure.Services
     /// </summary>
     public class MenuService : IMenuService
     {
-        private readonly WhatTheDob.Application.Interfaces.Services.IRatingThrottleService _throttleService;
+        private readonly IRatingThrottleService _throttleService;
         private readonly int _daysToFetch;
         private readonly string[] _meals;
         private readonly string _menuApiUrl;
@@ -39,7 +39,7 @@ namespace WhatTheDob.Infrastructure.Services
             IMenuItemMapper menuParser,
             IMenuFilterMapper menuFilterMapper,
             ILogger<MenuService> logger,
-            WhatTheDob.Application.Interfaces.Services.IRatingThrottleService throttleService)
+            IRatingThrottleService throttleService)
         {
             var fetchSettings = configuration.GetSection("MenuFetch");
 

--- a/src/WhatTheDob.Infrastructure/Services/MenuService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/MenuService.cs
@@ -228,7 +228,7 @@ namespace WhatTheDob.Infrastructure.Services
             });
         }
 
-        public async Task SubmitUserRatingAsync(string sessionId, string itemValue, int rating)
+        public async Task<(bool IsSuccess, string? FailureReason)> SubmitUserRatingAsync(string sessionId, string itemValue, int rating)
         {
             _logger.LogInformation("Submitting user rating: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}", 
                 sessionId, itemValue, rating);
@@ -240,31 +240,41 @@ namespace WhatTheDob.Infrastructure.Services
             if (string.IsNullOrWhiteSpace(trimmedSessionId))
             {
                 _logger.LogWarning("Rating submission failed: Session ID is empty");
-                throw new ArgumentException("Session id is required.", nameof(trimmedSessionId));
+                return (false, "Session id is required.");
             }
 
             if (string.IsNullOrWhiteSpace(trimmedItemValue))
             {
                 _logger.LogWarning("Rating submission failed: Item value is empty");
-                throw new ArgumentException("Item value is required.", nameof(trimmedItemValue));
+                return (false, "Item value is required.");
             }
 
             if (rating < 1 || rating > 5)
             {
                 _logger.LogWarning("Rating submission failed: Rating {Rating} is out of range (1-5)", rating);
-                throw new ArgumentOutOfRangeException(nameof(rating), rating, "Rating must be between 1 and 5.");
+                return (false, "Rating must be between 1 and 5.");
             }
 
             // Throttle check: allow maximum submissions per session per minute
             if (!_throttleService.IsAllowedAndRecord(trimmedSessionId))
             {
                 _logger.LogWarning("Rating submission throttled for SessionId={SessionId}", trimmedSessionId);
-                throw new InvalidOperationException("Rate limit exceeded. Please wait before submitting more ratings.");
+                return (false, "Rate limit exceeded. Please wait before submitting more ratings.");
             }
 
-            await _menuRepository.UpsertUserRatingAsync(trimmedSessionId, trimmedItemValue, rating).ConfigureAwait(false);
-            _logger.LogInformation("User rating successfully submitted: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}", 
-                trimmedSessionId, trimmedItemValue, rating);
+            try
+            {
+                await _menuRepository.UpsertUserRatingAsync(trimmedSessionId, trimmedItemValue, rating).ConfigureAwait(false);
+                _logger.LogInformation("User rating successfully submitted: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}", 
+                    trimmedSessionId, trimmedItemValue, rating);
+                return (true, null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Rating submission failed in repository for SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}",
+                    trimmedSessionId, trimmedItemValue, rating);
+                return (false, "Failed to submit rating. Please try again.");
+            }
         }
     }
 }

--- a/src/WhatTheDob.Infrastructure/Services/MenuService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/MenuService.cs
@@ -168,7 +168,7 @@ namespace WhatTheDob.Infrastructure.Services
         }
 
         // GetMenuAsync retrieves a menu for a specific date, campus, and meal from the repository and maps it to the domain entity.
-        public async Task<Menu> GetMenuAsync(string date, int campusId, int mealId)
+        public async Task<Menu?> GetMenuAsync(string date, int campusId, int mealId)
         {
             _logger.LogInformation("Retrieving menu for Date={Date}, CampusId={CampusId}, MealId={MealId}", 
                 date, campusId, mealId);

--- a/src/WhatTheDob.Infrastructure/Services/MenuService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/MenuService.cs
@@ -21,6 +21,7 @@ namespace WhatTheDob.Infrastructure.Services
     /// </summary>
     public class MenuService : IMenuService
     {
+        private readonly WhatTheDob.Application.Interfaces.Services.IRatingThrottleService _throttleService;
         private readonly int _daysToFetch;
         private readonly string[] _meals;
         private readonly string _menuApiUrl;
@@ -37,7 +38,8 @@ namespace WhatTheDob.Infrastructure.Services
             IMenuRepository menuRepository,
             IMenuItemMapper menuParser,
             IMenuFilterMapper menuFilterMapper,
-            ILogger<MenuService> logger)
+            ILogger<MenuService> logger,
+            WhatTheDob.Application.Interfaces.Services.IRatingThrottleService throttleService)
         {
             var fetchSettings = configuration.GetSection("MenuFetch");
 
@@ -51,6 +53,7 @@ namespace WhatTheDob.Infrastructure.Services
             _menuParser = menuParser;
             _menuFilterMapper = menuFilterMapper;
             _logger = logger;
+            _throttleService = throttleService;
             
             _logger.LogInformation("MenuService initialized with DaysToFetch={DaysToFetch}, SelectedCampus={CampusId}, MenuApiUrl={MenuApiUrl}", 
                 _daysToFetch, _campusId, _menuApiUrl);
@@ -250,6 +253,13 @@ namespace WhatTheDob.Infrastructure.Services
             {
                 _logger.LogWarning("Rating submission failed: Rating {Rating} is out of range (1-5)", rating);
                 throw new ArgumentOutOfRangeException(nameof(rating), rating, "Rating must be between 1 and 5.");
+            }
+
+            // Throttle check: allow maximum submissions per session per minute
+            if (!_throttleService.IsAllowedAndRecord(trimmedSessionId))
+            {
+                _logger.LogWarning("Rating submission throttled for SessionId={SessionId}", trimmedSessionId);
+                throw new InvalidOperationException("Rate limit exceeded. Please wait before submitting more ratings.");
             }
 
             await _menuRepository.UpsertUserRatingAsync(trimmedSessionId, trimmedItemValue, rating).ConfigureAwait(false);

--- a/src/WhatTheDob.Infrastructure/Services/RatingThrottleService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/RatingThrottleService.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.Caching.Memory;
+using WhatTheDob.Application.Interfaces.Services;
+
+namespace WhatTheDob.Infrastructure.Services
+{
+    public class RatingThrottleService : IRatingThrottleService
+    {
+        private readonly IMemoryCache _cache;
+        private readonly int _maxPerMinute = 5;
+
+        public RatingThrottleService(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public bool IsAllowedAndRecord(string sessionId)
+        {
+            if (string.IsNullOrWhiteSpace(sessionId)) return false;
+
+            // Use a simple counter stored in memory with a 1 minute sliding expiration
+            var cacheKey = $"rating_count:{sessionId}";
+            var counter = _cache.GetOrCreate(cacheKey, entry =>
+            {
+                entry.SlidingExpiration = TimeSpan.FromMinutes(1);
+                return 0;
+            });
+
+            // increment and check
+            var newCount = counter + 1;
+            _cache.Set(cacheKey, newCount, new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = TimeSpan.FromMinutes(1)
+            });
+
+            return newCount <= _maxPerMinute;
+        }
+    }
+}

--- a/src/WhatTheDob.Infrastructure/Services/RatingThrottleService.cs
+++ b/src/WhatTheDob.Infrastructure/Services/RatingThrottleService.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using WhatTheDob.Application.Interfaces.Services;
 
 namespace WhatTheDob.Infrastructure.Services
@@ -7,11 +8,15 @@ namespace WhatTheDob.Infrastructure.Services
     public class RatingThrottleService : IRatingThrottleService
     {
         private readonly IMemoryCache _cache;
-        private readonly int _maxPerMinute = 5;
+        private readonly int _maxPerMinute;
 
-        public RatingThrottleService(IMemoryCache cache)
+        public RatingThrottleService(IMemoryCache cache, IConfiguration configuration)
         {
             _cache = cache;
+
+            // Default to 10 if the config is missing or invalid.
+            var configuredLimit = configuration.GetValue<int?>("RatingThrottle:MaxPerMinute") ?? 10;
+            _maxPerMinute = Math.Max(1, configuredLimit);
         }
 
         public bool IsAllowedAndRecord(string sessionId)

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor
@@ -53,7 +53,7 @@ else
 {
     @if (_isRateLimitBannerVisible && !string.IsNullOrEmpty(_ratingErrorMessage))
     {
-        <div class="rate-limit-banner" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="rate-limit-banner card-style-md" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="rate-limit-banner-message">@_ratingErrorMessage</div>
             <div class="rate-limit-banner-meta">Try again in about @Math.Ceiling((_rateLimitCooldownPercent / 100d) * 60d) seconds.</div>
             <div class="rate-limit-cooldown-track">

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor
@@ -49,84 +49,103 @@
 {
     <p>Loading filters...</p>
 }
-else if (_isLoading)
-{
-    <p>Loading menu...</p>
-}
-else if (!string.IsNullOrEmpty(_errorMessage))
-{
-    <div class="alert alert-danger">@_errorMessage</div>
-}
-else if (_menu is null)
-{
-    <p>Select a date, campus, and meal, then click "Load Menu" to view the menu.</p>
-}
 else
 {
+    @if (_isRateLimitBannerVisible && !string.IsNullOrEmpty(_ratingErrorMessage))
+    {
+        <div class="rate-limit-banner" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="rate-limit-banner-message">@_ratingErrorMessage</div>
+            <div class="rate-limit-banner-meta">Try again in about @Math.Ceiling((_rateLimitCooldownPercent / 100d) * 60d) seconds.</div>
+            <div class="rate-limit-cooldown-track">
+                <div class="rate-limit-cooldown-fill" style="@($"width: {_rateLimitCooldownPercent:F1}%")"></div>
+            </div>
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(_ratingErrorMessage))
+    {
+        <div class="alert alert-danger">@_ratingErrorMessage</div>
+    }
 
-    <section class="menu-items">
-        @if (_menu.Items.Count == 0)
-        {
-            <p>No items were returned for this menu.</p>
-        }
-        else
-        {
-            var categoryIndex = 0;
-            @foreach (var category in _menu.Items.GroupBy(item => item.Category).OrderBy(g => g.Key))
+    @if (!string.IsNullOrEmpty(_menuErrorMessage))
+    {
+        <div class="alert alert-danger">@_menuErrorMessage</div>
+    }
+
+    @if (_isLoading)
+    {
+        <p>Loading menu...</p>
+    }
+    else if (_menu is null)
+    {
+        <p>Select a date, campus, and meal, then click "Load Menu" to view the menu.</p>
+    }
+    else
+    {
+
+        <section class="menu-items">
+            @if (_menu.Items.Count == 0)
             {
-                var colorIndex = categoryIndex % 8;
-                <div class="menu-category">
-                    <h3 class="category-header">@category.Key</h3>
-                    <ul class="menu-item-list">
-                        @foreach (var item in category)
-                        {
-                            <li class="menu-item card-style-lg">
-                                <div class="menu-item-header iterable-color-@colorIndex">
-                                    <h4>@item.Value</h4>
-                                </div>
-                                
-                                <div class="star-rating">
-                                    @{
-                                        var displayRating = GetDisplayRating(item);
-                                        var userRating = GetUserRating(item.Value);
-                                        bool isUserRated = userRating > 0;
-                                    }
-                                    @for (int i = 5; i >= 1; i--)
-                                    {
-                                        var starIndex = i;
-                                        var fillPercent = GetFillPercent(displayRating, starIndex);
-                                        var isPartial = fillPercent > 0 && fillPercent < 100;
-                                        var isFilled = fillPercent == 100;
-
-                                        <button type="button"
-                                                class="star-button @(isUserRated && isFilled ? "user" : "") @(isFilled ? "filled" : "") @(isPartial ? "partial" : "")"
-                                                style="@(isPartial ? $"--fill-percent: {fillPercent}%" : "")"
-                                                @onclick="() => SubmitRating(item.Value, starIndex)"
-                                                disabled="@_isSubmittingRating"
-                                                aria-label="Rate @starIndex out of 5"
-                                                title="Rate @starIndex out of 5">
-                                        </button>
-                                    }
-                                </div>
-                                <div class="rating-info">
-                                    <div class="line"></div>
-                                    <p>@(item.RatingCount == 0 ? "0.0" : ((double)item.TotalRating / item.RatingCount).ToString("0.0"))/5 (@item.RatingCount rating@(item.RatingCount == 1 ? "" : "s"))</p>
-                                </div>
-                                @if (item.Tags?.Count > 0)
-                                {
-                                    <div class="tags-list">
-                                        @foreach (var tag in item.Tags.SelectMany(t => t.Split(',')).Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t)))
+                <p>No items were returned for this menu.</p>
+            }
+            else
+            {
+                var categoryIndex = 0;
+                @foreach (var category in _menu.Items.GroupBy(item => item.Category).OrderBy(g => g.Key))
+                {
+                    var colorIndex = categoryIndex % 8;
+                    <div class="menu-category">
+                        <h3 class="category-header">@category.Key</h3>
+                        <ul class="menu-item-list">
+                            @foreach (var item in category)
+                            {
+                                <li class="menu-item card-style-lg">
+                                    <div class="menu-item-header iterable-color-@colorIndex">
+                                        <h4>@item.Value</h4>
+                                    </div>
+                                    
+                                    <div class="star-rating">
+                                        @{
+                                            var displayRating = GetDisplayRating(item);
+                                            var userRating = GetUserRating(item.Value);
+                                            bool isUserRated = userRating > 0;
+                                        }
+                                        @for (int i = 5; i >= 1; i--)
                                         {
-                                            <span class="tag-item" title="@tag">@GetTagShortName(tag)</span>
+                                            var starIndex = i;
+                                            var fillPercent = GetFillPercent(displayRating, starIndex);
+                                            var isPartial = fillPercent > 0 && fillPercent < 100;
+                                            var isFilled = fillPercent == 100;
+
+                                            <button type="button"
+                                                    class="star-button @(isUserRated && isFilled ? "user" : "") @(isFilled ? "filled" : "") @(isPartial ? "partial" : "")"
+                                                    style="@(isPartial ? $"--fill-percent: {fillPercent}%" : "")"
+                                                    @onclick="() => SubmitRating(item.Value, starIndex)"
+                                                    disabled="@_isSubmittingRating"
+                                                    aria-label="Rate @starIndex out of 5"
+                                                    title="Rate @starIndex out of 5">
+                                            </button>
                                         }
                                     </div>
-                                }
-                            </li>
-                        }
-                    </ul>
-                </div>
-                categoryIndex++;
+                                    <div class="rating-info">
+                                        <div class="line"></div>
+                                        <p>@(item.RatingCount == 0 ? "0.0" : ((double)item.TotalRating / item.RatingCount).ToString("0.0"))/5 (@item.RatingCount rating@(item.RatingCount == 1 ? "" : "s"))</p>
+                                    </div>
+                                    @if (item.Tags?.Count > 0)
+                                    {
+                                        <div class="tags-list">
+                                            @foreach (var tag in item.Tags.SelectMany(t => t.Split(',')).Select(t => t.Trim()).Where(t => !string.IsNullOrEmpty(t)))
+                                            {
+                                                <span class="tag-item" title="@tag">@GetTagShortName(tag)</span>
+                                            }
+                                        </div>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                    categoryIndex++;
+                }
             }
-        }
-    </section>
+        </section>
+    }
 }

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor.cs
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Http;
@@ -34,7 +35,14 @@ namespace WhatTheDob.Web.Components.Pages
         private bool _isLoading;
         private bool _isLoadingFilters = true;
         private bool _isSubmittingRating;
-        private string? _errorMessage;
+        private string? _menuErrorMessage;
+        private string? _ratingErrorMessage;
+        private bool _isRateLimitBannerVisible;
+        private double _rateLimitCooldownPercent;
+        private CancellationTokenSource? _rateLimitCooldownCts;
+
+        private const int RateLimitCooldownSeconds = 60;
+        private const int RateLimitTickMilliseconds = 200;
 
         private List<Campus> _campuses = new();
         private List<Meal> _meals = new();
@@ -83,7 +91,7 @@ namespace WhatTheDob.Web.Components.Pages
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Failed to load filters in Menu page initialization");
-                _errorMessage = "Failed to load filters. Please refresh the page.";
+                _menuErrorMessage = "Failed to load filters. Please refresh the page.";
             }
             finally
             {
@@ -95,7 +103,7 @@ namespace WhatTheDob.Web.Components.Pages
         {
             if (!_selectedCampusId.HasValue || !_selectedMealId.HasValue)
             {
-                _errorMessage = "Please select both a campus and a meal.";
+                _menuErrorMessage = "Please select both a campus and a meal.";
                 Logger.LogWarning("Menu load attempted without valid selections: CampusId={CampusId}, MealId={MealId}",
                     _selectedCampusId, _selectedMealId);
                 StateHasChanged();
@@ -103,7 +111,7 @@ namespace WhatTheDob.Web.Components.Pages
             }
 
             _isLoading = true;
-            _errorMessage = null;
+            _menuErrorMessage = null;
             StateHasChanged();
 
             try
@@ -116,7 +124,7 @@ namespace WhatTheDob.Web.Components.Pages
 
                 if (_menu is null)
                 {
-                    _errorMessage = "No menu found for the selected date, campus, and meal.";
+                    _menuErrorMessage = "No menu found for the selected date, campus, and meal.";
                     Logger.LogInformation("No menu found for Date={Date}, CampusId={CampusId}, MealId={MealId}",
                         formattedDate, _selectedCampusId.Value, _selectedMealId.Value);
                 }
@@ -130,7 +138,7 @@ namespace WhatTheDob.Web.Components.Pages
             {
                 Logger.LogError(ex, "Failed to load menu for Date={Date}, CampusId={CampusId}, MealId={MealId}",
                     _selectedDate.ToString("MM/dd/yy"), _selectedCampusId.Value, _selectedMealId.Value);
-                _errorMessage = "Failed to load menu. Please try again.";
+                _menuErrorMessage = "Failed to load menu. Please try again.";
             }
             finally
             {
@@ -143,10 +151,15 @@ namespace WhatTheDob.Web.Components.Pages
         {
             if (string.IsNullOrEmpty(_sessionId))
             {
-                _errorMessage = "Session ID not found. Please refresh the page.";
+                _ratingErrorMessage = "Session ID not found. Please refresh the page.";
                 Logger.LogWarning("Rating submission attempted without session ID for ItemValue={ItemValue}", itemValue);
                 StateHasChanged();
                 return;
+            }
+
+            if (!_isRateLimitBannerVisible)
+            {
+                _ratingErrorMessage = null;
             }
 
             _isSubmittingRating = true;
@@ -161,11 +174,19 @@ namespace WhatTheDob.Web.Components.Pages
 
                 if (!isSuccess)
                 {
-                    _errorMessage = failureReason ?? "Failed to submit rating. Please try again.";
+                    _ratingErrorMessage = failureReason ?? "Failed to submit rating. Please try again.";
+
+                    if (IsRateLimitFailure(_ratingErrorMessage))
+                    {
+                        ShowRateLimitBanner(_ratingErrorMessage);
+                    }
+
                     Logger.LogWarning("Rating submission rejected: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}, Reason={Reason}",
-                        _sessionId, itemValue, rating, _errorMessage);
+                        _sessionId, itemValue, rating, _ratingErrorMessage);
                     return;
                 }
+
+                _ratingErrorMessage = null;
 
                 _userRatings[itemValue] = rating;
                 await SaveUserRatingToCookiesAsync(itemValue, rating);
@@ -184,13 +205,77 @@ namespace WhatTheDob.Web.Components.Pages
             {
                 Logger.LogError(ex, "Failed to submit rating: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}",
                     _sessionId, itemValue, rating);
-                _errorMessage = "Failed to submit rating. Please try again.";
+                _ratingErrorMessage = "Failed to submit rating. Please try again.";
             }
             finally
             {
                 _isSubmittingRating = false;
                 StateHasChanged();
             }
+        }
+
+        private static bool IsRateLimitFailure(string? failureReason)
+        {
+            return !string.IsNullOrWhiteSpace(failureReason)
+                && failureReason.Contains("rate limit", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ShowRateLimitBanner(string message)
+        {
+            _ratingErrorMessage = message;
+            _isRateLimitBannerVisible = true;
+            _rateLimitCooldownPercent = 100;
+
+            _rateLimitCooldownCts?.Cancel();
+            _rateLimitCooldownCts?.Dispose();
+
+            _rateLimitCooldownCts = new CancellationTokenSource();
+            _ = RunRateLimitCooldownAsync(_rateLimitCooldownCts.Token);
+        }
+
+        private async Task RunRateLimitCooldownAsync(CancellationToken cancellationToken)
+        {
+            var cooldownStart = DateTime.UtcNow;
+            var cooldownDuration = TimeSpan.FromSeconds(RateLimitCooldownSeconds);
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var elapsed = DateTime.UtcNow - cooldownStart;
+                    if (elapsed >= cooldownDuration)
+                    {
+                        break;
+                    }
+
+                    var remaining = cooldownDuration - elapsed;
+                    _rateLimitCooldownPercent = Math.Clamp((remaining.TotalMilliseconds / cooldownDuration.TotalMilliseconds) * 100d, 0d, 100d);
+
+                    await InvokeAsync(StateHasChanged);
+                    await Task.Delay(RateLimitTickMilliseconds, cancellationToken);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _isRateLimitBannerVisible = false;
+            _ratingErrorMessage = null;
+            _rateLimitCooldownPercent = 0;
+
+            await InvokeAsync(StateHasChanged);
+        }
+
+        public void Dispose()
+        {
+            _rateLimitCooldownCts?.Cancel();
+            _rateLimitCooldownCts?.Dispose();
         }
 
         private double GetDisplayRating(MenuItem item)

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor.cs
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor.cs
@@ -157,7 +157,15 @@ namespace WhatTheDob.Web.Components.Pages
                 Logger.LogInformation("Submitting rating: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}",
                     _sessionId, itemValue, rating);
 
-                await MenuService.SubmitUserRatingAsync(_sessionId, itemValue, rating);
+                var (isSuccess, failureReason) = await MenuService.SubmitUserRatingAsync(_sessionId, itemValue, rating);
+
+                if (!isSuccess)
+                {
+                    _errorMessage = failureReason ?? "Failed to submit rating. Please try again.";
+                    Logger.LogWarning("Rating submission rejected: SessionId={SessionId}, ItemValue={ItemValue}, Rating={Rating}, Reason={Reason}",
+                        _sessionId, itemValue, rating, _errorMessage);
+                    return;
+                }
 
                 _userRatings[itemValue] = rating;
                 await SaveUserRatingToCookiesAsync(itemValue, rating);

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor.css
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor.css
@@ -58,6 +58,43 @@
     box-shadow: 2px 2px #000000;
 }
 
+.rate-limit-banner {
+    margin-bottom: 1rem;
+    padding: 0.85rem 1rem;
+    border: 3px solid #000000;
+    border-radius: 10px;
+    box-shadow: 5px 5px #000000;
+    background: linear-gradient(110deg, #ffe6a7 0%, #ffd166 60%, #f9c74f 100%);
+}
+
+.rate-limit-banner-message {
+    font-weight: 700;
+    color: #2d1b00;
+    margin-bottom: 0.25rem;
+}
+
+.rate-limit-banner-meta {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #5f3a00;
+    margin-bottom: 0.45rem;
+}
+
+.rate-limit-cooldown-track {
+    width: 100%;
+    height: 0.5rem;
+    border: 2px solid #000000;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.55);
+    overflow: hidden;
+}
+
+.rate-limit-cooldown-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #ef476f 0%, #f77f00 100%);
+    transition: width 0.15s linear;
+}
+
 .menu-metadata {
     margin-bottom: 2rem;
     padding: 1rem;

--- a/src/WhatTheDob.Web/Components/Pages/Menu.razor.css
+++ b/src/WhatTheDob.Web/Components/Pages/Menu.razor.css
@@ -61,9 +61,6 @@
 .rate-limit-banner {
     margin-bottom: 1rem;
     padding: 0.85rem 1rem;
-    border: 3px solid #000000;
-    border-radius: 10px;
-    box-shadow: 5px 5px #000000;
     background: linear-gradient(110deg, #ffe6a7 0%, #ffd166 60%, #f9c74f 100%);
 }
 

--- a/src/WhatTheDob.Web/Program.cs
+++ b/src/WhatTheDob.Web/Program.cs
@@ -79,7 +79,7 @@ builder.Services.AddHttpClient<IMenuApiClient, MenuApiClient>();
 builder.Services.AddSingleton<IDailyMenuJob, DailyMenuJob>();
 // Rating throttle to limit submissions per session id
 builder.Services.AddMemoryCache();
-builder.Services.AddSingleton<WhatTheDob.Application.Interfaces.Services.IRatingThrottleService, WhatTheDob.Infrastructure.Services.RatingThrottleService>();
+builder.Services.AddSingleton<IRatingThrottleService, RatingThrottleService>();
 
 var app = builder.Build();
 

--- a/src/WhatTheDob.Web/Program.cs
+++ b/src/WhatTheDob.Web/Program.cs
@@ -77,6 +77,9 @@ builder.Services.AddScoped<IMenuItemMapper, MenuItemMapper>();
 builder.Services.AddScoped<IMenuFilterMapper, MenuFilterMapper>();
 builder.Services.AddHttpClient<IMenuApiClient, MenuApiClient>();
 builder.Services.AddSingleton<IDailyMenuJob, DailyMenuJob>();
+// Rating throttle to limit submissions per session id
+builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<WhatTheDob.Application.Interfaces.Services.IRatingThrottleService, WhatTheDob.Infrastructure.Services.RatingThrottleService>();
 
 var app = builder.Build();
 

--- a/src/WhatTheDob.Web/appsettings.json
+++ b/src/WhatTheDob.Web/appsettings.json
@@ -9,6 +9,9 @@
     "CookieKey": "UserSessionId",
     "DaysToExpire": 7
   },
+  "RatingThrottle": {
+    "MaxPerMinute": 10
+  }, 
   "MenuFetch": {
     "InitialFetch": true,
     "SelectedCampus": 46,

--- a/tests/WhatTheDob.Infrastructure.Tests/MenuServiceTests.cs
+++ b/tests/WhatTheDob.Infrastructure.Tests/MenuServiceTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using WhatTheDob.Application.Interfaces.Services;
 using WhatTheDob.Application.Interfaces.Services.External;
 using WhatTheDob.Domain.Entities;
 using WhatTheDob.Infrastructure.Interfaces.Mapping;
@@ -17,7 +18,10 @@ namespace WhatTheDob.Infrastructure.Tests;
 
 public class MenuServiceTests
 {
-    private static MenuService CreateService(IMenuRepository repository, ILogger<MenuService>? logger = null)
+    private static MenuService CreateService(
+        IMenuRepository repository,
+        ILogger<MenuService>? logger = null,
+        IRatingThrottleService? throttleService = null)
     {
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -26,13 +30,16 @@ public class MenuServiceTests
             ["MenuFetch:SelectedCampus"] = "1"
         }).Build();
 
+        throttleService ??= Mock.Of<IRatingThrottleService>(s => s.IsAllowedAndRecord(It.IsAny<string>()) == true);
+
         return new MenuService(
             configuration,
             Mock.Of<IMenuApiClient>(),
             repository,
             Mock.Of<IMenuItemMapper>(),
             Mock.Of<IMenuFilterMapper>(),
-            logger ?? Mock.Of<ILogger<MenuService>>());
+            logger ?? Mock.Of<ILogger<MenuService>>(),
+            throttleService);
     }
 
     [Theory]
@@ -43,9 +50,10 @@ public class MenuServiceTests
         var repoMock = new Mock<IMenuRepository>(MockBehavior.Strict);
         var service = CreateService(repoMock.Object);
 
-        var act = async () => await service.SubmitUserRatingAsync(session!, "Item", 3);
+        var result = await service.SubmitUserRatingAsync(session!, "Item", 3);
 
-        await act.Should().ThrowAsync<System.ArgumentException>();
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Be("Session id is required.");
         repoMock.VerifyNoOtherCalls();
     }
 
@@ -57,9 +65,10 @@ public class MenuServiceTests
         var repoMock = new Mock<IMenuRepository>(MockBehavior.Strict);
         var service = CreateService(repoMock.Object);
 
-        var act = async () => await service.SubmitUserRatingAsync("session", item!, 3);
+        var result = await service.SubmitUserRatingAsync("session", item!, 3);
 
-        await act.Should().ThrowAsync<System.ArgumentException>();
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Be("Item value is required.");
         repoMock.VerifyNoOtherCalls();
     }
 
@@ -71,10 +80,56 @@ public class MenuServiceTests
         var repoMock = new Mock<IMenuRepository>(MockBehavior.Strict);
         var service = CreateService(repoMock.Object);
 
-        var act = async () => await service.SubmitUserRatingAsync("session", "Item", rating);
+        var result = await service.SubmitUserRatingAsync("session", "Item", rating);
 
-        await act.Should().ThrowAsync<System.ArgumentOutOfRangeException>();
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Be("Rating must be between 1 and 5.");
         repoMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SubmitUserRatingAsync_rejects_when_throttled()
+    {
+        var repoMock = new Mock<IMenuRepository>(MockBehavior.Strict);
+        var throttleMock = new Mock<IRatingThrottleService>();
+        throttleMock.Setup(t => t.IsAllowedAndRecord("session")).Returns(false);
+        var service = CreateService(repoMock.Object, throttleService: throttleMock.Object);
+
+        var result = await service.SubmitUserRatingAsync("session", "Item", 3);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Be("Rate limit exceeded. Please wait before submitting more ratings.");
+        repoMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SubmitUserRatingAsync_returns_success_for_valid_request()
+    {
+        var repoMock = new Mock<IMenuRepository>();
+        repoMock.Setup(r => r.UpsertUserRatingAsync("session", "Item", 5, default)).Returns(Task.CompletedTask);
+        var service = CreateService(repoMock.Object);
+
+        var result = await service.SubmitUserRatingAsync("session", "Item", 5);
+
+        result.IsSuccess.Should().BeTrue();
+        result.FailureReason.Should().BeNull();
+        repoMock.Verify(r => r.UpsertUserRatingAsync("session", "Item", 5, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitUserRatingAsync_returns_failure_when_repository_throws()
+    {
+        var repoMock = new Mock<IMenuRepository>();
+        repoMock.Setup(r => r.UpsertUserRatingAsync("session", "Item", 4, default))
+            .ThrowsAsync(new System.Exception("db unavailable"));
+
+        var service = CreateService(repoMock.Object);
+
+        var result = await service.SubmitUserRatingAsync("session", "Item", 4);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Be("Failed to submit rating. Please try again.");
+        repoMock.Verify(r => r.UpsertUserRatingAsync("session", "Item", 4, default), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
PR Notes: AI-Assisted Code Modernization & Review

This PR documents the process of utilizing an AI coding assistant to implement a rate-limiting feature and modernize the backend architecture, followed by manual code reviews and architectural corrections.
Commit 1: AI Generation - Rating Throttle Service Setup

Prompt:

    "I need to protect this rating submission method from spam on the backend. Please create a new C# class called RatingThrottleService that uses IMemoryCache to track submissions and restrict users to a maximum of 5 ratings per minute based on their Session ID (stored in cookies). We will need to register this service in Program.cs and implement the check inside my SubmitRatingAsync method."

AI Summary:

    Added IRatingThrottleService interface.

    Implemented RatingThrottleService using IMemoryCache.

    Limited to 5 submissions per minute per session ID via a memory counter with a 1-minute sliding expiration.

    Injected and used the throttle inside SubmitUserRatingAsync in MenuService to deny submissions when the throttle is exceeded.

    Throws InvalidOperationException with the message "Rate limit exceeded..." when exceeded.

    Registered IMemoryCache and the throttle service in Dependency Injection in Program.cs.

Developer Notes & Review:

    Critique: The AI added unnecessary namespaces in Program.cs and MenuService.cs (i.e., WhatTheDob.Application.Interfaces.Services.IRatingThrottleService).

    Bug Found: Upon testing, when a user goes over the rate limit, an exception is thrown and the menu items section is cleared entirely. This occurs in SubmitUserRatingAsync, which also contains other conditionals that throw exceptions.

    Architectural Pivot: This highlights a good opportunity to improve the codebase. I plan to change this function to utilize a Result pattern—returning true or false (pass or fail) along with a string detailing the output, rather than using exceptions for expected control flow.

Commit 2: Manual Fix - Namespace Cleanup

Manual Changes:

    Removed unnecessary, fully-qualified namespaces in Program.cs and MenuService.cs generated by the AI to align with project styling.

Next Steps:

    Change SubmitUserRatingAsync to return true on success and false with a reason (string) on failure. Update all dependent implementations and tests.

Commit 3: AI Generation - Implementing the Result Pattern

Prompt:

    "We want to change this function by removing the exception throws. We will now return true on success and false on fail along with the reason for failure. All other implementations of this (including tests) will need to be updated as well."

AI Summary:

    Service Contract: Changed to return a result tuple: Task<(bool IsSuccess, string? FailureReason)> SubmitUserRatingAsync(...).

    MenuService Implementation: Changed to return fail reasons instead of throwing exceptions:

        Missing session -> (false, "Session id is required.")

        Missing item value -> (false, "Item value is required.")

        Rating outside 1..5 -> (false, "Rating must be between 1 and 5.")

        Throttle blocked -> (false, "Rate limit exceeded. Please wait before submitting more ratings.")

        Repository exception caught/logged -> (false, "Failed to submit rating. Please try again.")

        Success -> (true, null)

    UI Caller (Menu.razor.cs): Updated to use the result instead of the exception flow. On failure, it sets _errorMessage and returns early. On success, it continues with the cookie save and menu refresh.

    Tests: Updated for new behavior and expanded coverage (throttled request failure, successful submission, repository exception failure).

Developer Notes & Review:

    Critique: The model did a great job with this. All existing tests were updated and passed. It smartly wrapped the UpsertUserRatingAsync call in a try/catch and created two new tests for the try/catch and the rate-limiting conditional.

    Architectural Thoughts: I considered if it would be beneficial to have all service layer methods return a result object. I decided against it, as this is the only method where failures like "rate limit exceeded" and "invalid input" are normal, expected user outcomes rather than system failures.

    UI Bug Identified: When manually testing the rate limiting, the menu items section is still being cleared and replaced with an error message. This happens because our _errorMessage state is shared between menu-loading errors and rating errors.

    Configuration Tweak: 5 ratings per minute is too strict; it is easy for a normal user to accidentally hit this limit. It should be adjusted to 10 ratings and moved to appsettings.json to be configurable.

    Unrelated Fix: Spotted a possible null reference in GetMenuAsync.

Next Steps:

    Fix the null reference in GetMenuAsync.

    Move _maxPerMinute to app settings and change the default to 10.

    Update the page state model to use separate errors for menu-loading vs. rating submission.

Commit 4: Manual Fix - Null Reference Resolution

Manual Changes:

    Changed GetMenuAsync and IGetMenuAsync to utilize a nullable return type in the event no menu is returned. All tests passed.

Commit 5: Manual Fix - Configuration Extraction

Manual Changes:

    Extracted the _maxPerMinute hardcoded value. The rating throttle service now configures this via appsettings.json under MaxPerMinute, with a default fallback of 10.

    Added logic to clamp _maxPerMinute to a minimum of 1 if a negative number is entered.

Commit 6: AI Generation - UI State Separation & Cooldown Banner

Prompt:

    "When SubmitUserRatingAsync returns false, the menu section is cleared and an error message is shown. This is not a desired outcome. It seems that we need to change the page state model to use separate errors for menu-loading vs rating submission so that we can still see the menu items when this error appears. We will want to show this error using a non-closable alert banner, that disappears after 1 minute (the rate limit period). This alert banner will have a cooldown bar that shows the progress. We will need to be able to handle the user hitting the rate limit while the banner is still visible."

AI Summary:

    State Separation (Menu.razor.cs): Replaced _errorMessage with _menuErrorMessage (for load errors) and _ratingErrorMessage (for submit errors).

    Banner Logic: Added rate-limit banner state (_isRateLimitBannerVisible, _rateLimitCooldownPercent) and a 60-second cooldown loop. If throttled again while visible, the cooldown is restarted via timer cancellation tokens (implemented IDisposable).

    UI Rendering (Menu.razor): Refactored rendering so rating errors display independently from the menu state. Added a dedicated rate-limit banner with a message and cooldown bar.

    Styling (Menu.razor.css): Added custom CSS classes for the banner, message, track, and fill.

Developer Notes & Review:

    Testing: The UI behaves exactly as expected:

        Going over rate limit -> UI shows banner.

        Trying to rate while under limit -> UI loading bar resets properly.

        Submitting an invalid rating -> UI shows error, then disappears after a valid rating.

        Invalid menu fetch -> UI shows fetch error independently.

    Critique: While functional, the AI-generated UI did not follow the project's existing CSS standards. It created its own custom border styling instead of utilizing the existing card-style-md utility classes.

Commit 7: Manual Fix - UI Standardization

Manual Changes:

    Removed the custom border styling the AI agent generated for the alert banner.

    Refactored the component to use the existing card-style-md class to maintain design system consistency across the application.

closes #22 